### PR TITLE
Fix for localhost vs IP cypress testing issue

### DIFF
--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -11,7 +11,7 @@ from sympy import simplify, sympify, oo, Symbol
 
 import constants
 import logger
-import math_utils
+from graph_utils import error_coordinates, delta_coordinates
 from input import Input, convert
 from wolfram_client import WolframClient
 
@@ -57,8 +57,8 @@ async def analyze(request: Request):
             "wolfram_limit": WolframClient.limit(str(simple)),
             "limit": json.dumps(float(limit)),
             "denominator_limit": json.dumps(float(q_limit)),
-            "log_error": json.dumps(math_utils.error_coordinates(simple, x, limit)),
-            "delta": json.dumps(math_utils.delta_coordinates(simple, simple_q, x, limit)),
+            "log_error": json.dumps(error_coordinates(simple, x, limit)),
+            "delta": json.dumps(delta_coordinates(simple, simple_q, x, limit)),
             "computed_value": json.dumps(float(limit))  # @TODO: replace with actual computation to i
         }
 

--- a/react-frontend/src/components/Form.tsx
+++ b/react-frontend/src/components/Form.tsx
@@ -58,7 +58,7 @@ function Form() {
 		};
 		console.log(body);
 		axios
-			.post('http://127.0.0.1:8000/analyze', body)
+			.post('http://localhost:8000/analyze', body)
 			.then((response) => {
 				if (response.status == 200) {
 					setResults(response.data);

--- a/react-frontend/vite.config.js
+++ b/react-frontend/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 import eslint from 'vite-plugin-eslint';
 import react from '@vitejs/plugin-react';
+// for the following see https://github.com/cypress-io/cypress/issues/25397#issuecomment-1775454875
+import dns from 'dns'
+dns.setDefaultResultOrder('ipv4first')
 
 export default defineConfig(() => {
 	return {


### PR DESCRIPTION
Well this was an odd one... The React frontend could interact with the Python backend using localhost when the Analyze button was click. Cypress performing the same button click did not trigger a call to the Python API. My initial fix was changing the url invoked by the button click to `127.0.0.1` instead of `localhost`, but the IP didn't sit right with me. I tried several other fixes, but [enabling `ipv4first`](https://github.com/cypress-io/cypress/issues/25397#issuecomment-1775454875) is the only one that worked. This is due to a fairly recent change to NodeJS documented [here](https://nodejs.org/api/dns.html#dnssetdefaultresultorderorder) and further explained [here](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback) as setting `verbatim` to false in dns lookup, which prioritized ipv4 addresses over ipv6:

> verbatim [<boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type) When true, the callback receives IPv4 and IPv6 addresses in the order the DNS resolver returned them. When false, IPv4 addresses are placed before IPv6 addresses. Default: true (addresses are not reordered).