### PR TITLE
Renaming workflows so they appear distinct in GitHub UI

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -1,4 +1,4 @@
-name: Commit Workflow
+name: Python Unit Tests
 on:
   push
 jobs:

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -1,4 +1,4 @@
-name: Commit Workflow
+name: Frontend Tests
 on:
   push
 jobs:


### PR DESCRIPTION
I might break these workflows up further, but for now the frontend and backend appear the same in the actions UI since I started with one and created the other by copying at first. This makes it hard to determine which is which when reviewing results, so I am just renaming them for now.