### PR TITLE
Deploy the Ramanujan Machine Web Portal to an AWS EC2 Instance

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Stop Running Container
       run: | 
-        ssh ec2 'docker stop $(docker ps -a -q)'
+        ssh ec2 'docker ps -q | xargs --no-run-if-empty docker stop | xargs --no-run-if-empty docker rm'
 
     - name: Configure Docker & Load Image
       run: |

--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -1,0 +1,76 @@
+name: Build and Deploy to Cloud
+
+on:
+  push:
+#    branches:
+#      - main
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        apt update -y && apt install -y curl
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        chmod +x get-docker.sh
+        ./get-docker.sh
+
+    - name: Build Docker image
+      run: docker build -t ramanujan-machine-web-portal:latest .
+
+    - name: Save Docker image as tarball
+      run: |
+        docker save ramanujan-machine-web-portal:latest | gzip > image.tar.gz
+        ls -al image.tar*
+
+
+    - name: Prepare SSH Dir
+      run: |
+        mkdir -pv ~/.ssh/
+
+    - name: Write Key
+      env:
+        EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+      run: |
+        echo "$EC2_SSH_KEY" > ~/.ssh/actions.key
+        chmod 600 ~/.ssh/actions.key
+
+#    - name: Add Key to Known Hosts
+#      run: |
+#          ssh-keyscan -v "${{ secrets.EC2_HOST }}" >> ~/.ssh/actions.pub
+
+    - name: Write SSH Config
+      env:
+        EC2_HOST: ${{ secrets.EC2_HOST }}
+        EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
+      run: |
+        cat >>~/.ssh/config <<END
+        Host ec2
+            HostName $EC2_HOST
+            User $EC2_USERNAME
+            IdentityFile ~/.ssh/actions.key
+            StrictHostKeyChecking=no
+            ServerAliveCountMax=10
+            ServerAliveInterval=60
+        END
+
+    - name: Copy Docker image to EC2 instance
+      run: |
+        scp image.tar.gz ec2:/home/ubuntu
+
+    - name: Stop Running Container
+      run: | 
+        ssh ec2 'docker stop $(docker ps -a -q)'
+
+    - name: Configure Docker & Load Image
+      run: |
+        ssh ec2 "docker load -i /home/ubuntu/image.tar.gz"
+
+    - name: Run Docker container on EC2 instance
+      run: |
+        ssh ec2 "docker run -d -p 8080:5137 ramanujan-machine-web-portal:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:latest
 LABEL description="Ramanujan Machine Web Portal"
 
 # set working directory
-WORKDIR /srv/ramanujan-machine-portal
+WORKDIR /srv/ramanujan-machine-web-portal
 
 # install node
 RUN apt-get update && apt-get -y install python3 python3-pip ca-certificates curl gnupg

--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -7014,9 +7014,9 @@
 			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.3",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-			"integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+			"integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
 			"funding": [
 				{
 					"type": "individual",


### PR DESCRIPTION
For the time being, the deployment will happen for every commit. Later on, I will change it to only fire on merge to main.
 
This workflow comprises a few interesting tidbits and lessons.

- Created an AWS EC2 nano instance running Ubuntu Server
- Configured EC2_HOST, EC2_USERNAME and EC2_SSH_KEY secrets in GitHub settings (Note that line breaks in pem file must be persisted in GitHub secret)
- Had to `sudo groupadd docker` and  `sudo usermod -aG docker ubuntu` and reboot the EC2 instance for docker to work
- Figured out that you can gzip docker image tarballs... sure helps with `scp`-ing them onto the server without timing out
- uncommented and set sshd client timeout values (`ClientAliveInterval 30` and 
`ClientAliveCountMax 20`) and restarted ssh daemon to help with intermittent connection drops
- Created elastic IP because AWS kept closing the ssh connection during deployment and I had to keep updating the EC2_HOST secret when I restarted the box (it would slow down as it ran out of space before sizing)
- Upsized EBS volume to 16 GB from original 10 GB
- Added step to clean up stale docker artifacts

NOTE: GitHub has [a bajillion CIDR blocks](https://api.github.com/meta) so I could not add them all to the security policy because they impose a limit on the allowed entries. This is problematic as for this to work the ssh port has to be open to the entire web. I will create a separate story to address this, probably by adding the CIDR blocks directly to the sshd_config on the server.