### PR TITLE
Fixing meta text describing web app and fixing the missing Wolfram app id env var

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -21,7 +21,9 @@ jobs:
         ./get-docker.sh
 
     - name: Build Docker image
-      run: docker build -t ramanujan-machine-web-portal:latest .
+      env:
+        WOLFRAM_APP_ID: ${{ secrets.WOLFRAM_APP_ID }}
+      run: docker build --build-arg wolfram_app_id=$WOLFRAM_APP_ID -t ramanujan-machine-web-portal:latest .
 
     - name: Save Docker image as tarball
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL description="Ramanujan Machine Web Portal"
 
 # set working directory
 WORKDIR /srv/ramanujan-machine-web-portal
+ARG wolfram_app_id
+ENV WOLFRAM_APP_ID=$wolfram_app_id
 
 # install node
 RUN apt-get update && apt-get -y install git python3 python3-pip python3.10-venv ca-certificates curl gnupg libpq-dev libgmp-dev libmpfr-dev libmpc-dev
@@ -40,6 +42,5 @@ EXPOSE 5173
 EXPOSE 8000
 
 COPY docker_start.sh docker_start.sh
-# local COPY .env .env
 RUN chmod +x docker_start.sh
 CMD ./docker_start.sh

--- a/react-frontend/index.html
+++ b/react-frontend/index.html
@@ -5,7 +5,7 @@
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#000000" />
-		<meta name="description" content="Web site created using create-react-app" />
+		<meta name="description" content="The Ramanujan Machine Web Portal - a novel way to do mathematics" />
 		<!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
I noticed when I shared the new IP in Slack it had boilerplate text so I replaced it with an excerpt from their Wordpress for the time being:

```html
<meta name="description" content="The Ramanujan Machine Web Portal - a novel way to do mathematics" />
```

I also made sure that the docker container had access to the Wolfram App ID which I must have accidentally pulled in from my own env in the past but when I checked the app and the docker env in production it was missing and the call was failing in the backend.