### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ To run the web portal using the Dockerfile:
 
 Note that the first port is the port you can access via your web browser, e.g. `http://localhost:80` is where you would be able to interact with the app given the above configuration. You can change `80` to whatever port you wish, but the frontend of the web application runs on port `5173` inside the container.
 
-## Run with Docker
-Refer to [React Frontend README](./react-frontend/README.md) to run locally.
+## Run Frontend and Backend Locally without Docker
+- Refer to [React Frontend README](./react-frontend/README.md) to run the web interface locally.
+- Refer to [Python Backend README](./python-backend/README.md) to run the API locally.


### PR DESCRIPTION
The second heading was wrong and the API backend execution had not been added to the instructions.