### PR TITLE
Handle the use case where both a_n and b_n are numbers

### DIFF
--- a/python-backend/graph_utils.py
+++ b/python-backend/graph_utils.py
@@ -27,6 +27,8 @@ def error_coordinates(values: list[mpmath.mpf], limit: mpmath.mpf) -> list[Point
     x_y_pairs = []
     for i in range(0, len(values)):
         if values[i] is not None:
+            # taking log 10 gives us the order of magnitude of the difference -  the number of zeros after the decimal
+            # which is a gauge of the proximity of the value at n to the "limit"
             y_value = mpmath.log10(abs(values[i] - limit))
             if i <= DEBUG_LINES:
                 logger.debug(f"Error {i} {values[i]} difference: {values[i] - limit} "
@@ -67,7 +69,12 @@ def delta_coordinates(values: list[mpmath.mpf], q_values: list[mpmath.mpf], limi
     x_y_pairs = []
     # graph coords of error delta: -1 * (log(|Pn/Qn - L|) / log(Qn)) - 1
     for i in range(1, min(len(values), len(q_values))):
-        if values[i] is not None and q_values[i] is not None and mpmath.log10(q_values[i]) != 0:
+        # we test for values that would generate irrational results or exceptions
+        # e.g. divide by zero when taking log10 of 1
+        # taking log 10 gives us the order of magnitude of the difference -  the number of zeros after the decimal
+        # which is a gauge of the proximity of the value at n to the "limit"
+        # in this case we are then comparing that precision to the precision of the denominator
+        if values[i] is not None and q_values[i] is not None and q_values[i] > 0 and q_values[i] != 1:
             y_value = (mpmath.mpf(-1) *
                        (mpmath.log10(abs(values[i] - limit)) / mpmath.log10(q_values[i]))
                        - mpmath.mpf(1))

--- a/python-backend/graph_utils.py
+++ b/python-backend/graph_utils.py
@@ -67,7 +67,7 @@ def delta_coordinates(values: list[mpmath.mpf], q_values: list[mpmath.mpf], limi
     x_y_pairs = []
     # graph coords of error delta: -1 * (log(|Pn/Qn - L|) / log(Qn)) - 1
     for i in range(1, min(len(values), len(q_values))):
-        if values[i] is not None and q_values[i] is not None and q_values[i] > 0:
+        if values[i] is not None and q_values[i] is not None and mpmath.log10(q_values[i]) != 0:
             y_value = (mpmath.mpf(-1) *
                        (mpmath.log10(abs(values[i] - limit)) / mpmath.log10(q_values[i]))
                        - mpmath.mpf(1))

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -51,8 +51,8 @@ def parse(data: Input) -> tuple[sympy.core, sympy.core, sympy.core, Symbol]:
     :return: tuple including p/q, simplified q and the symbol/variable used in these expressions
     """
     x = Symbol(data.symbol, real=True)
-    a = sympify(convert(data.a), {data.symbol: x})
-    b = sympify(convert(data.b), {data.symbol: x})
+    a = sympify(convert(data.a), {data.symbol: x}) if (len(data.symbol) == 1) else sympify(convert(data.a))
+    b = sympify(convert(data.b), {data.symbol: x}) if (len(data.symbol) == 1) else sympify(convert(data.b))
     expression = a / b
     return expression, a, b, x
 

--- a/react-frontend/src/components/Form.tsx
+++ b/react-frontend/src/components/Form.tsx
@@ -56,7 +56,7 @@ function Form() {
 		const body: PostBody = {
 			a: polynomialA,
 			b: polynomialB,
-			symbol: polynomialA.match(/([a-zA-Z])/)?.[0] ?? polynomialB.match(/([a-zA-Z])/)?.[0],
+			symbol: polynomialA.match(/([a-zA-Z])/)?.[0] ?? polynomialB.match(/([a-zA-Z])/)?.[0] ?? '',
 			i: iterationCount
 		};
 		axios


### PR DESCRIPTION
The application was tested with inputs a = 1 and b = 1 and failed silently because the symbol was a required field but none was found. This unearthed that such inputs are valid and should be handled by the backend. 

Also resolved an unhandled divide by zero error. There was a test for zero denominator but, after refactoring the function, the value being tested was never updated to the new denominator.