### PR TITLE
hide d3 auto generated curve

### DIFF
--- a/react-frontend/src/components/ScatterPlot.tsx
+++ b/react-frontend/src/components/ScatterPlot.tsx
@@ -53,10 +53,10 @@ const ScatterPlot = ({ id, data }:{id:string, data: CoordinatePair[]}) =>  {
                 .call(d3.axisLeft(yScale));
             yAxis.attr("transform",`translate(${h_margin},${v_margin})`);
 
-            const line = d3
+            /* const line = d3
             .line<CoordinatePair>()
             .x((d) => xScale(d.x))
-            .y((d) => yScale(parseFloat(d.y))).curve(d3.curveBasis);
+            .y((d) => yScale(parseFloat(d.y))).curve(d3.curveBasis); */
 
             svg.append('g')
             .selectAll("dot")
@@ -69,7 +69,7 @@ const ScatterPlot = ({ id, data }:{id:string, data: CoordinatePair[]}) =>  {
               .attr("transform", `translate(${h_margin}, ${v_margin})`)
               .style("fill", "var(--accent)");
 
-              svg
+              /* svg
             .data([filteredData])
             .append('path')
             .attr('d', line)
@@ -78,7 +78,7 @@ const ScatterPlot = ({ id, data }:{id:string, data: CoordinatePair[]}) =>  {
             .attr("stroke-dasharray", "2 2")
             .attr("stroke-opacity", "0.6")
             .attr("stroke-width", "2")
-            .attr("stroke", "var(--muted)");
+            .attr("stroke", "var(--muted)"); */
 
         }
     }, [data]);


### PR DESCRIPTION
I added an d3 autogenerated curve as a POC and hoped that it would stand in as a best fit line, but it really doesn't. Hiding it until I have a better approach.

Now it will display just the actual points:

<img width="525" alt="image" src="https://github.com/gt-sse-center/ramanujan-machine-web/assets/1794406/79ee85b6-e08e-4b00-8f7d-0c83c8b60567">

without this pretty but not useful blue stuff:

<img width="525" alt="image" src="https://github.com/gt-sse-center/ramanujan-machine-web/assets/1794406/4c541528-e49e-4a40-ab18-aa12b421722e">

