### PR TITLE
adding standalone lint command

### DIFF
--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -23,6 +23,7 @@
 	"scripts": {
 		"start": "vite",
 		"build": "tsc && vite build",
+		"lint": "eslint --fix src/**/*.ts*",
 		"serve": "vite preview"
 	},
 	"eslintConfig": {


### PR DESCRIPTION
While the frontend build operation includes linting, there was no standalone step to lint and output what is wrong with formatting or auto-fix code formatting issues.