### PR TITLE
adding closed form source to results page

### DIFF
--- a/react-frontend/src/App.css
+++ b/react-frontend/src/App.css
@@ -263,7 +263,7 @@ div.closed-form-container {
 	flex-wrap: wrap;
 	justify-content: space-evenly;
 	align-items: center;
-	padding-top: 1rem;
+	padding-top: 0.5rem;
 }
 div.closed-form {
 	padding: 0px 20px;
@@ -328,4 +328,16 @@ p.footnote {
 }
 svg {
 	margin: 20px 10px 20px 20px;
+}
+
+div.chart-container mjx-container[jax='SVG'][display='true'] {
+	margin: 0px;
+}
+
+div.flex-wrapper {
+	display: flex;
+}
+
+div.flex-child {
+	flex: 1;
 }

--- a/react-frontend/src/components/Charts.tsx
+++ b/react-frontend/src/components/Charts.tsx
@@ -121,13 +121,21 @@ function Charts({
 	return (
 		<div className="chart-container">
 			<MathJaxContext config={config} src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
-				<div>
-					<p>
-						<MathJax inline dynamic>
-							{wrapExpression(a_n, 'a[n]')}
-							{wrapExpression(b_n, 'b[n]')}
-						</MathJax>
-					</p>
+				<div className="flex-wrapper">
+					<div className="flex-child">
+						<p>
+							<MathJax inline dynamic>
+								{wrapExpression(a_n, 'a[n]')}
+							</MathJax>
+						</p>
+					</div>
+					<div className="flex-child">
+						<p>
+							<MathJax inline dynamic>
+								{wrapExpression(b_n, 'b[n]')}
+							</MathJax>
+						</p>
+					</div>
 				</div>
 				{limit ? (
 					<div>
@@ -147,13 +155,43 @@ function Charts({
 				)}
 				{convergesTo ? (
 					<div className="full-width top-padding">
-						<p className="center-content">It seems to converge to:</p>
+						<p className="center-content">It seems to converge to</p>
+						<div className="top-padding center-text">
+							<p className="footnote">
+								<i>
+									Results from{' '}
+									<a
+										href="https://github.com/RamanujanMachine/LIReC"
+										aria-description="Link to LIReC GitHub repository README.">
+										LIReC identify()
+									</a>
+								</i>
+							</p>
+						</div>
 						<div className="closed-form-container">
 							<div className="closed-form">
 								<MathJax inline dynamic>
 									{computeValue()}
 								</MathJax>
 							</div>
+						</div>
+						{wolframResults ? (
+							<div className="top-padding center-text">
+								<p className="footnote">
+									<i>
+										Results from{' '}
+										<a
+											href="https://www.wolframalpha.com/"
+											aria-description="Link to WolframAlpha web interface.">
+											WolframAlpha
+										</a>
+									</i>
+								</p>
+							</div>
+						) : (
+							''
+						)}
+						<div className="closed-form-container">
 							{wolframResults?.map((r: WolframResult) =>
 								wolframValue(r.plaintext) ? (
 									<div className="closed-form" key={r.plaintext}>


### PR DESCRIPTION
User request to display the source of the closed form expressions. "Results from WolframAlpha" and "Results from LIReC identify()" with links to each added and pictured below:

<img width="507" alt="image" src="https://github.com/gt-sse-center/ramanujan-machine-web/assets/1794406/761965ed-162a-4b28-8e51-b4e282d8eb99">
