### PR TITLE
Name constants and link to documentation, if available

### DIFF
--- a/python-backend/constants.py
+++ b/python-backend/constants.py
@@ -5,8 +5,8 @@ PRECISION = 30
 HOSTS = ['localhost', '127.0.0.1']
 PORTS = ['5173', '80']
 # how many lines of a series to print for debugging purposes
-DEBUG_LINES = 100
+DEBUG_LINES = 10
 # evalf allows for verbose output via param universally set to this:
 VERBOSE_EVAL = False
 # chunk size to send to front end via web socket when computing coordinate pairs
-BATCH_SIZE = 250
+BATCH_SIZE = 500

--- a/python-backend/input.py
+++ b/python-backend/input.py
@@ -48,13 +48,13 @@ def parse(data: Input) -> tuple[Callable, Number, Callable, Number, Symbol]:
         else sympify(b_formatted, rational=True)
 
     # define functions for input expressions
-    def a(x: Number):
+    def a(x: Number) -> mpf:
         """
         Function representation of a
         """
         return mpf(a_symp.evalf(subs={variable: x}, n=PRECISION, strict=True, verbose=constants.VERBOSE_EVAL))
 
-    def b(x: Number):
+    def b(x: Number) -> mpf:
         """
         Function representation of b
         """

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -107,12 +107,16 @@ async def data_socket(websocket: WebSocket):
             logger.debug(f"last convergent / limit: {limit}")
             await websocket.send_json({"limit": "Infinity" if type(limit) is Infinity else str(limit)})
 
+            # @TODO replace wide_search=True with wide_search=[1]
             computed_values = db.identify(values=[str(limit)], wide_search=True)
+            json_computed_values = []
             for m in computed_values:
                 logger.debug(f"identify returned: {m}")
+                json_computed_values.append(str(m))
 
             await websocket.send_json(
-                {"converges_to": json.dumps(str(computed_values[0] if len(computed_values) > 0 else None))})
+                {"converges_to": json.dumps(json_computed_values)}
+            )
 
             await chart_coordinates(values,
                                     num_values,

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -108,7 +108,7 @@ async def data_socket(websocket: WebSocket):
             await websocket.send_json({"limit": "Infinity" if type(limit) is Infinity else str(limit)})
 
             # @TODO replace wide_search=True with wide_search=[1]
-            computed_values = db.identify(values=[str(limit)], wide_search=True)
+            computed_values: list[str] = db.identify(values=[str(limit)], wide_search=True)
             json_computed_values = []
             for m in computed_values:
                 logger.debug(f"identify returned: {m}")

--- a/python-backend/wolfram_client.py
+++ b/python-backend/wolfram_client.py
@@ -19,7 +19,7 @@ class WolframClient:
     """
 
     @staticmethod
-    def ask(query: str, include_pod: str = None) -> str:
+    def ask(query: str, include_pod: str = None) -> dict:
         """
         Invoke the Wolfram Alpha Results API which will allow us to perform various mathematical calculations to
         cross-check our results. Refer to https://products.wolframalpha.com/api/documentation for usage.
@@ -52,7 +52,7 @@ class WolframClient:
                 logger.error("Failed to parse Wolfram API result", e)
 
     @staticmethod
-    def limit(expression: str) -> str:
+    def limit(expression: str) -> list:
         """
         Query the Wolfram results API for limits of a string expression
         :param expression: Mathematical expression for which we would like to compute the limit(s)
@@ -66,7 +66,7 @@ class WolframClient:
             logger.error("Failed to obtain Wolfram API result", e)
 
     @staticmethod
-    def closed_form(expression: str) -> dict[str, str]:
+    def closed_form(expression: str) -> dict:
         """
         Query the Wolfram results API for limits of a string expression
         :param expression: Mathematical expression for which we would like to compute the limit(s)
@@ -74,18 +74,17 @@ class WolframClient:
         """
         try:
             result = WolframClient.ask(query=expression, include_pod="PossibleClosedForm")
-            print(result)
             # only want to return: queryresult -> pods[0] -> subpods
             # infos has metadata on the subpods e.g. the constant names and links to reference content
             # Note: the index of the infos does not line up with the index of the closed form results
             subpods = result["queryresult"]["pods"][0]["subpods"]
-            meta = result["queryresult"]["pods"][0]["infos"] if "infos" in result["queryresult"]["pods"][0] else []
+            meta = result["queryresult"]["pods"][0].get("infos", [])
             return {"closed_forms": subpods, "metadata": meta}
         except Exception as e:
             logger.error("Failed to obtain Wolfram API result", e)
 
     @staticmethod
-    def raw(expression: str) -> str:
+    def raw(expression: str) -> dict:
         """
         Query the Wolfram results API with a string expression
         :param expression: Mathematical expression for which we would like to get more information
@@ -99,7 +98,7 @@ class WolframClient:
             logger.error("Failed to obtain Wolfram API result", e)
 
     @staticmethod
-    def continued_fraction(expression: str) -> str:
+    def continued_fraction(expression: str) -> list:
         """
         Query the Wolfram results API for the continued fraction form of an expression
         :param expression: Mathematical expression for which we would like to retrieve the continued fraction form

--- a/python-backend/wolfram_client.py
+++ b/python-backend/wolfram_client.py
@@ -66,7 +66,7 @@ class WolframClient:
             logger.error("Failed to obtain Wolfram API result", e)
 
     @staticmethod
-    def closed_form(expression: str) -> str:
+    def closed_form(expression: str) -> dict[str, str]:
         """
         Query the Wolfram results API for limits of a string expression
         :param expression: Mathematical expression for which we would like to compute the limit(s)
@@ -74,8 +74,13 @@ class WolframClient:
         """
         try:
             result = WolframClient.ask(query=expression, include_pod="PossibleClosedForm")
+            print(result)
             # only want to return: queryresult -> pods[0] -> subpods
-            return result["queryresult"]["pods"][0]["subpods"]
+            # infos has metadata on the subpods e.g. the constant names and links to reference content
+            # Note: the index of the infos does not line up with the index of the closed form results
+            subpods = result["queryresult"]["pods"][0]["subpods"]
+            meta = result["queryresult"]["pods"][0]["infos"]
+            return {"closed_forms": subpods, "metadata": meta}
         except Exception as e:
             logger.error("Failed to obtain Wolfram API result", e)
 

--- a/python-backend/wolfram_client.py
+++ b/python-backend/wolfram_client.py
@@ -79,7 +79,7 @@ class WolframClient:
             # infos has metadata on the subpods e.g. the constant names and links to reference content
             # Note: the index of the infos does not line up with the index of the closed form results
             subpods = result["queryresult"]["pods"][0]["subpods"]
-            meta = result["queryresult"]["pods"][0]["infos"]
+            meta = result["queryresult"]["pods"][0]["infos"] if "infos" in result["queryresult"]["pods"][0] else []
             return {"closed_forms": subpods, "metadata": meta}
         except Exception as e:
             logger.error("Failed to obtain Wolfram API result", e)

--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -80,27 +80,27 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
-			"integrity": "sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+			"integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.24.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
-			"integrity": "sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
+			"integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.24.2",
-				"@babel/generator": "^7.24.1",
+				"@babel/generator": "^7.24.4",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.24.1",
-				"@babel/parser": "^7.24.1",
+				"@babel/helpers": "^7.24.4",
+				"@babel/parser": "^7.24.4",
 				"@babel/template": "^7.24.0",
 				"@babel/traverse": "^7.24.1",
 				"@babel/types": "^7.24.0",
@@ -164,9 +164,9 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
-			"integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+			"integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.24.0",
@@ -228,9 +228,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.1.tgz",
-			"integrity": "sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz",
+			"integrity": "sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
@@ -511,9 +511,9 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
-			"integrity": "sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
+			"integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.24.0",
@@ -611,15 +611,31 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-			"integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+			"integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.4.tgz",
+			"integrity": "sha512-qpl6vOOEEzTLLcsuqYYo8yDtrTocmu2xkGvgNebvPjT9DTtfFYGmgDqY+rBYXNlqL4s9qLDn6xkrJv4RxAPiTA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-plugin-utils": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -1158,9 +1174,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.1.tgz",
-			"integrity": "sha512-h71T2QQvDgM2SmT29UYU6ozjMlAt7s7CSs5Hvy8f8cf/GM/Z4a2zMfN+fjVGaieeCrXR3EdQl6C4gQG+OgmbKw==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.4.tgz",
+			"integrity": "sha512-nIFUZIpGKDf9O9ttyRXpHFpKC+X3Y5mtshZONuEUYBomAKoM4y029Jr+uB1bHGPhNmK8YXHevDtKDOLmtRrp6g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.0"
@@ -1189,12 +1205,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.1.tgz",
-			"integrity": "sha512-FUHlKCn6J3ERiu8Dv+4eoz7w8+kFLSyeVG4vDAikwADGjUCoHw/JHokyGtr8OR4UjpwPVivyF+h8Q5iv/JmrtA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.4.tgz",
+			"integrity": "sha512-B8q7Pz870Hz/q9UgP8InNpY01CSLDSCyqX7zcRuv3FcPl87A2G17lASroHWaCtbdIcbYzOZ7kWmXFKbijMSmFg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.1",
+				"@babel/helper-create-class-features-plugin": "^7.24.4",
 				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			},
@@ -1941,13 +1957,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.1.tgz",
-			"integrity": "sha512-liYSESjX2fZ7JyBFkYG78nfvHlMKE6IpNdTVnxmlYUR+j5ZLsitFbaAE+eJSK2zPPkNWNw4mXL51rQ8WrvdK0w==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.4.tgz",
+			"integrity": "sha512-79t3CQ8+oBGk/80SQ8MN3Bs3obf83zJ0YZjDmDaEZN8MqhMI760apl5z6a20kFeMXBwJX99VpKT8CKxEBp5H1g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-create-class-features-plugin": "^7.24.1",
+				"@babel/helper-create-class-features-plugin": "^7.24.4",
 				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-typescript": "^7.24.1"
 			},
@@ -2022,15 +2038,16 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.24.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.3.tgz",
-			"integrity": "sha512-fSk430k5c2ff8536JcPvPWK4tZDwehWLGlBp0wrsBUjZVdeQV6lePbwKWZaZfK2vnh/1kQX1PzAJWsnBmVgGJA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.4.tgz",
+			"integrity": "sha512-7Kl6cSmYkak0FK/FXjSEnLJ1N9T/WA2RkMhu17gZ/dsxKJUuTYNIylahPTzqpLyJN4WhDif8X0XK1R8Wsguo/A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.24.1",
+				"@babel/compat-data": "^7.24.4",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-validator-option": "^7.23.5",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.4",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.1",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.1",
 				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.1",
@@ -2057,9 +2074,9 @@
 				"@babel/plugin-transform-async-generator-functions": "^7.24.3",
 				"@babel/plugin-transform-async-to-generator": "^7.24.1",
 				"@babel/plugin-transform-block-scoped-functions": "^7.24.1",
-				"@babel/plugin-transform-block-scoping": "^7.24.1",
+				"@babel/plugin-transform-block-scoping": "^7.24.4",
 				"@babel/plugin-transform-class-properties": "^7.24.1",
-				"@babel/plugin-transform-class-static-block": "^7.24.1",
+				"@babel/plugin-transform-class-static-block": "^7.24.4",
 				"@babel/plugin-transform-classes": "^7.24.1",
 				"@babel/plugin-transform-computed-properties": "^7.24.1",
 				"@babel/plugin-transform-destructuring": "^7.24.1",
@@ -2184,9 +2201,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-			"integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+			"integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -2324,9 +2341,9 @@
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.2.tgz",
-			"integrity": "sha512-RpHaZ1h9LE7aALeQXmXrJkRG84ZxIsctEN2biEUmFyKpzFM3zZ35eUMcIzZFsw/2olQE6v69+esEqU2f1MKycg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.3.tgz",
+			"integrity": "sha512-KEPNw4+WW5AVEIyzC80rTbWEUatTW2lXpN8+8ILC8PiPeWPjwUzrPZDIOZ2wwqDmeqOYTdSGyL3+vE5GC3FB3Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2940,9 +2957,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -3571,9 +3588,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
-			"integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
+			"integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
 			"cpu": [
 				"arm"
 			],
@@ -3584,9 +3601,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
-			"integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
+			"integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3597,9 +3614,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
-			"integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
+			"integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3610,9 +3627,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
-			"integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
+			"integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
 			"cpu": [
 				"x64"
 			],
@@ -3623,9 +3640,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
-			"integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
+			"integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
 			"cpu": [
 				"arm"
 			],
@@ -3636,9 +3653,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
-			"integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
+			"integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3649,9 +3666,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
-			"integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
+			"integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3661,10 +3678,23 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
+			"integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+			"cpu": [
+				"ppc64le"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
-			"integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
+			"integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3674,10 +3704,23 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
+			"integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
-			"integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
+			"integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
 			"cpu": [
 				"x64"
 			],
@@ -3688,9 +3731,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
-			"integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
+			"integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
 			"cpu": [
 				"x64"
 			],
@@ -3701,9 +3744,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
-			"integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
+			"integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3714,9 +3757,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
-			"integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
+			"integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
 			"cpu": [
 				"ia32"
 			],
@@ -3727,9 +3770,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
-			"integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
+			"integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
 			"cpu": [
 				"x64"
 			],
@@ -3740,9 +3783,9 @@
 			]
 		},
 		"node_modules/@rushstack/eslint-patch": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.8.0.tgz",
-			"integrity": "sha512-0HejFckBN2W+ucM6cUOlwsByTKt9/+0tWhqUffNIcHqCXkthY/mZ7AuYPK/2IIaGWhdl0h+tICDO0ssLMd6XMQ==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.1.tgz",
+			"integrity": "sha512-S3Kq8e7LqxkA9s7HKLqXGTGck1uwis5vAXan3FnU5yw1Ec5hsSGnq4s/UCaSqABPOnOTg7zASLyst7+ohgWexg==",
 			"dev": true
 		},
 		"node_modules/@sinclair/typebox": {
@@ -3884,9 +3927,9 @@
 			}
 		},
 		"node_modules/@testing-library/react": {
-			"version": "14.2.2",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.2.tgz",
-			"integrity": "sha512-SOUuM2ysCvjUWBXTNfQ/ztmnKDmqaiPV3SvoIuyxMUca45rbSWWAT/qB8CUs/JQ/ux/8JFs9DNdFQ3f6jH3crA==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.0.tgz",
+			"integrity": "sha512-AYJGvNFMbCa5vt1UtDCa/dcaABrXq8gph6VN+cffIx0UeA0qiGqS+sT60+sb+Gjc8tGXdECWYQgaF0khf8b+Lg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
@@ -4202,9 +4245,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.6",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
-			"integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
+			"version": "8.56.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
+			"integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -4311,9 +4354,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.11.30",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-			"integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+			"version": "20.12.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
+			"integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -4332,30 +4375,23 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "18.2.71",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.71.tgz",
-			"integrity": "sha512-PxEsB9OjmQeYGffoWnYAd/r5FiJuUw2niFQHPc2v2idwh8wGPkkYzOHuinNJJY6NZqfoTCiOIizDOz38gYNsyw==",
+			"version": "18.2.74",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
+			"integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
-				"@types/scheduler": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "18.2.22",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.22.tgz",
-			"integrity": "sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==",
+			"version": "18.2.24",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.24.tgz",
+			"integrity": "sha512-cN6upcKd8zkGy4HU9F1+/s98Hrp6D4MOcippK4PoE8OZRngohHZpbJn1GsaDLz87MqvHNoT13nHvNqM9ocRHZg==",
 			"dev": true,
 			"dependencies": {
 				"@types/react": "*"
 			}
-		},
-		"node_modules/@types/scheduler": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
-			"integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==",
-			"dev": true
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.8",
@@ -4426,15 +4462,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
-			"integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.5.0.tgz",
+			"integrity": "sha512-cj+XGhNujfD2/wzR1tabNsidnYRaFfEkcULdcIyVBYcXjBvBKOes+mpMBP7hMpOyk+gBcfXsrg4NBGAStQyxjQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.4.0",
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/typescript-estree": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/scope-manager": "7.5.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/typescript-estree": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -4454,13 +4490,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
-			"integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
+			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0"
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4555,9 +4591,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4568,13 +4604,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
-			"integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
+			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -4718,12 +4754,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
-			"integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
+			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -5615,9 +5651,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001600",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
-			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+			"version": "1.0.30001607",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
+			"integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
 			"dev": true,
 			"funding": [
 				{
@@ -5996,9 +6032,9 @@
 			"dev": true
 		},
 		"node_modules/cypress": {
-			"version": "13.7.1",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.1.tgz",
-			"integrity": "sha512-4u/rpFNxOFCoFX/Z5h+uwlkBO4mWzAjveURi3vqdSu56HPvVdyGTxGw4XKGWt399Y1JwIn9E1L9uMXQpc0o55w==",
+			"version": "13.7.2",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.2.tgz",
+			"integrity": "sha512-FF5hFI5wlRIHY8urLZjJjj/YvfCBrRpglbZCLr/cYcL9MdDe0+5usa8kTIrDHthlEc9lwihbkb5dmwqBDNS2yw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -6755,9 +6791,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.717",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
-			"integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==",
+			"version": "1.4.729",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz",
+			"integrity": "sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -6819,9 +6855,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.23.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
-			"integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
+			"version": "1.23.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+			"integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
 			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.1",
@@ -6863,11 +6899,11 @@
 				"safe-regex-test": "^1.0.3",
 				"string.prototype.trim": "^1.2.9",
 				"string.prototype.trimend": "^1.0.8",
-				"string.prototype.trimstart": "^1.0.7",
+				"string.prototype.trimstart": "^1.0.8",
 				"typed-array-buffer": "^1.0.2",
 				"typed-array-byte-length": "^1.0.1",
 				"typed-array-byte-offset": "^1.0.2",
-				"typed-array-length": "^1.0.5",
+				"typed-array-length": "^1.0.6",
 				"unbox-primitive": "^1.0.2",
 				"which-typed-array": "^1.1.15"
 			},
@@ -12060,9 +12096,9 @@
 			"integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
 		},
 		"node_modules/rollup": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
-			"integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
+			"integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "1.0.5"
@@ -12075,19 +12111,21 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.13.0",
-				"@rollup/rollup-android-arm64": "4.13.0",
-				"@rollup/rollup-darwin-arm64": "4.13.0",
-				"@rollup/rollup-darwin-x64": "4.13.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.13.0",
-				"@rollup/rollup-linux-arm64-musl": "4.13.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.13.0",
-				"@rollup/rollup-linux-x64-gnu": "4.13.0",
-				"@rollup/rollup-linux-x64-musl": "4.13.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.13.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.13.0",
-				"@rollup/rollup-win32-x64-msvc": "4.13.0",
+				"@rollup/rollup-android-arm-eabi": "4.14.1",
+				"@rollup/rollup-android-arm64": "4.14.1",
+				"@rollup/rollup-darwin-arm64": "4.14.1",
+				"@rollup/rollup-darwin-x64": "4.14.1",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
+				"@rollup/rollup-linux-arm64-gnu": "4.14.1",
+				"@rollup/rollup-linux-arm64-musl": "4.14.1",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
+				"@rollup/rollup-linux-riscv64-gnu": "4.14.1",
+				"@rollup/rollup-linux-s390x-gnu": "4.14.1",
+				"@rollup/rollup-linux-x64-gnu": "4.14.1",
+				"@rollup/rollup-linux-x64-musl": "4.14.1",
+				"@rollup/rollup-win32-arm64-msvc": "4.14.1",
+				"@rollup/rollup-win32-ia32-msvc": "4.14.1",
+				"@rollup/rollup-win32-x64-msvc": "4.14.1",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -13221,9 +13259,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-			"integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -13404,13 +13442,13 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.2.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.2.6.tgz",
-			"integrity": "sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
+			"integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.20.1",
-				"postcss": "^8.4.36",
+				"postcss": "^8.4.38",
 				"rollup": "^4.13.0"
 			},
 			"bin": {

--- a/react-frontend/src/App.css
+++ b/react-frontend/src/App.css
@@ -341,3 +341,7 @@ div.flex-wrapper {
 div.flex-child {
 	flex: 1;
 }
+a.metadata {
+	font-size: 0.8rem;
+	font-weight: normal;
+}

--- a/react-frontend/src/App.css
+++ b/react-frontend/src/App.css
@@ -334,6 +334,18 @@ div.chart-container mjx-container[jax='SVG'][display='true'] {
 	margin: 0px;
 }
 
+.meta-container mjx-container svg {
+	margin: 0px;
+}
+
+.meta-container {
+	text-align: center;
+}
+
+.meta-container mjx-container[jax='SVG'][display='true'] {
+	display: inline;
+}
+
 div.flex-wrapper {
 	display: flex;
 }
@@ -341,7 +353,7 @@ div.flex-wrapper {
 div.flex-child {
 	flex: 1;
 }
-a.metadata {
+.metadata {
 	font-size: 0.8rem;
 	font-weight: normal;
 }

--- a/react-frontend/src/components/Charts.tsx
+++ b/react-frontend/src/components/Charts.tsx
@@ -102,13 +102,11 @@ function Charts({
 	const convertLirecConstants = (input: string) => {
 		let constantMeta: LirecConstantMetadata[] = [];
 		let cleanString = input;
-		// all of the LIReC constants use just these characters
-		const notConstChars = '[^a-zA-Z0-9_\\[\\[]';
 		for (const c in constants) {
-			const t1 = new RegExp(`${notConstChars}+${c}${notConstChars}`);
-			const t2 = new RegExp(`${notConstChars}+${c}$`);
-			// make sure it's not a substring of another constant name
-			if (t1.test(cleanString) || t2.test(cleanString)) {
+			// make sure it's not a substring of another constant name by checking that the constant name
+			// we are processing is either surrounded by non-constant characters or at the beginning/end of the string
+			const tightPattern = new RegExp(`(^|\\W+|\\[[^\\]]*\\])${c}(\\W+|\\[[^\\]]*\\]|$)`);
+			if (tightPattern.test(cleanString)) {
 				if (constants[c].replacement) {
 					cleanString = cleanString.replaceAll(c, constants[c].replacement!!);
 				}

--- a/react-frontend/src/components/Form.tsx
+++ b/react-frontend/src/components/Form.tsx
@@ -19,7 +19,7 @@ function Form() {
 	const [showCharts, setShowCharts] = useState(false);
 	const [noConvergence, setNoConvergence] = useState(false);
 	const [waitingForResponse, setWaitingForResponse] = useState(false);
-	const [convergesTo, setConvergesTo] = useState('');
+	const [convergesTo, setConvergesTo] = useState([]);
 	const [limit, setLimit] = useState('');
 	const [errorData, setErrorData] = useState<CoordinatePair[]>([]);
 	const [deltaData, setDeltaData] = useState<CoordinatePair[]>([]);
@@ -30,7 +30,7 @@ function Form() {
 	}, []);
 
 	const resetState = function () {
-		setConvergesTo('');
+		setConvergesTo([]);
 		setLimit('');
 		setErrorData([]);
 		setDeltaData([]);
@@ -82,6 +82,7 @@ function Form() {
 				symbol: polynomialA.match(/([a-zA-Z])/)?.[0] ?? polynomialB.match(/([a-zA-Z])/)?.[0] ?? '',
 				i: iterationCount
 			};
+
 			websocket.send(JSON.stringify(body));
 			setWaitingForResponse(true);
 		};

--- a/react-frontend/src/lib/constants.ts
+++ b/react-frontend/src/lib/constants.ts
@@ -1,95 +1,349 @@
 interface Constant {
-    name?: string, 
-    replacement?: string
+	name?: string;
+	replacement?: string;
+	url?: string;
 }
 
 // See https://github.com/RamanujanMachine/LIReC/blob/main/LIReC/lib/calculator.py for each of the following keys
 // make sure these are alpha sorted because otherwise e.g. alpha will be replaced instead of alpha_GW
-const constants: {[abbrev: string]: Constant } = {
-	"alpha_GW": {"name": "Goemans Williamson Constant", "replacement": "α[GW]"},
-	"alpha_M": {"name": "Madelung Constant", "replacement": "α[M]"},
-	"alpha_F": {"name": "Foias Constant", "replacement": "α[F]"},
-	"alpha": {"name": "Second Feigenbaum Constant", "replacement": "α"},
-	"A_Pi": {"name": "Mills Constant", "replacement": "A[π]"},
-	"A": {"name": "Glaisher Kinkelin Constant"},
-	"beta_Levy": {"name": "First Lévy Constant", "replacement": "β"},
-	"beta": {"name": "Bernstein Constant", "replacement": "β"},
-	"B_2": {"name": "Brun Constant", "replacement": "B[2]"},
-	"B_H": {"name": "Backhouse Constant", "replacement": "B[H]"},
-	"cbrt2": {"replacement": "cbrt(2)"},
-	"cbrt3": {"replacement": "cbrt(3)"},
-	"C_Artin": {"name": "Artin Constant", "replacement": "C[Artin]"},
-	"C_HBM": {"name": "Heath-Brown–Moroz Constant", "replacement": "C[HBM]"},
-	"C_CE": {"name": "Copeland Erdős Constant", "replacement": "C[CE]"},
-	"C_FT": {"name": "Feller Tornier Constant", "replacement": "C[FT]"},
-	"C_10": {"name": "Base 10 Champernowne Constant", "replacement": "C[10]"},
-	"C_1": {"name": "First Continued Fraction Constant", "replacement": "C[1]"},
-	"C_N": {"name": "Niven Constant", "replacement": "C[N]"},
-	"C_P": {"name": "Porter Constant", "replacement": "C[P]"},
-	"C_2": {"name": "Second du Bois-Reymond Constant", "replacement": "C[2]"},
-	"C": {"name": "Catalan Constant"},
-	"c": {"name": "Asymptotic Lebesgue Constant", "replacement": "Λ[n]"},
-	"delta_ETF": {"name": "Erdős-Tenenbaum-Ford Constant", "replacement": "δ[ETF]"},
-	"delta_G": {"name": "Gompertz Constant", "replacement": "δ[G]"},
-	"Delta_3": {"name": "Robbins Constant", "replacement": "∆(3)"},
-	"delta": {"name": "First Feigenbaum Constant", "replacement": "δ"},
-	"D_V": {"name": "Devicci Tesseract Constant", "replacement": "D[V]"},
-	"D": {"name": "Dottie Number"},
-	"eLevy": {"name": "Second Lévy Constant", "replacement": "e^β"},
-	"epi": {"name": "Gelfond Constant", "replacement": "e^π"},
-	"E": {"name": "Erdos Borwein constant"},
-	"F": {"name": "Fransén Robinson Constant"},
-	"gamma": {"name": "Euler Mascheroni Constant"},
-	"G_025": {"replacement": "Γ(0.25)"},
-	"G_L": {"name": "Gieseking Constant or Lobachevsky Constant", "replacement": "G[L]"},
-	"G_S": {"name": "Gelfond-Schneider Constant or Hilbert Number", "replacement": "2^sqrt(2)"},
-	"g": {"name": "Golden Angle"},
-	"G": {"name": "Gauss Constant (ϖ/π)"},
-	"Kprime": {"replacement": "Κ","name": "Kepler Bouwkamp Constant"},
-	"K_0": {"name": "Khinchin Constant", "replacement": "K[0]"},
-	"lambda_GD": {"name": "Golomb Dickman Constant", "replacement": "λ[GD]"},
-	"lambda_C": {"name": "Conway Constant", "replacement": "λ[C]"},
-	"ln2": {"replacement": "ln(2)"},
-	"L_lim": {"name": "Laplace Limit", "replacement": "L[lim]"},
-	"L_Lochs": {"name": "Loch Constant", "replacement": "L[Lochs]"},
-	"L_1": {"name": "First Lemniscate Constant (ϖ/2)", "replacement": "L[1]"},
-	"L_2": {"name": "Secnd Lemniscate Constant (π/(2ϖ))", "replacement": "L[2]"},
-	"L_R": {"name": "Landau Ramanujan Constant", "replacement": "L[R]"},
-	"L_D": {"name": "Logarithmic Capacity of the Unit Disk", "replacement": "L[D]"},
-	"L": {"name": "Liouville Constant"},
-	"mu": {"replacement": "μ", "name": "Hexagonal Lattice Connective Constant"},
-	"M": {"name": "Meissel Mertens Constant"},
-	"Omega": {"replacement": "Ω","name": "Omega Constant"},
-	"phi": {"name": "Golden Ratio"},
-	"psi_Fib": {"name": "Reciprocal Fibonacci Constant", "replacement": "ψ[Fib]"},
-	"psi": {"replacement": "ψ", "name": "Super Golden Ratio"},
-	"Pi_2": {"name": "Twin Primes Constant", "replacement": "Π[2]"},
-	"P_Dragon": {"name": "Paperfolding Constant", "replacement": "P[Dragon]"},
-	"P": {"name": "Universal Parabolic Constant"},
-	"q": {"name": "Komornik–Loreti Constant"},
-	"root12of2": {"replacement": "nthRoot(2, 12)"},
-	"rho_Pi": {"name": "Prime Constant", "replacement": "ρ[Pi]"},
-	"rho": {"name": "Plastic Number", "replacement": "Ρ"},
-	"R_S": {"name": "Ramanujan Soldner Constant", "replacement": "R[S]"},
-	"R": {"name": "Ramanujan Constant"},
-	"sigma_10": {"name": "Salem Constant", "replacement": "σ[10]"},
-	"sigma_S": {"name": "Somos Quadratic Recurrence Constant", "replacement": "σ[S]"},
-	"sigma": {"name": "Hafner-Sarnak-McCurley Constant", "replacement": "σ"},
-	"sqrt2": {"replacement": "sqrt(2)"},
-	"sqrt3": {"replacement": "sqrt(3)"},
-	"S_MRB": {"name": "MRB Constant", "replacement": "S[MRB]"},
-	"S_Pi": {"name": "Stephens Constant", "replacement": "S[Pi]"},
-	"S": {"name": "Sierpiński Constant"},
-	"theta_m": {"name": "Magic Angle", "replacement": "θ[m]"},
-	"tau": {"name": "Prouhet Thue Morse Constant", "replacement": "τ"},
-	"T_Pi": {"name": "Taniguchi Constant", "replacement": "T[Pi]"},
-	"T": {"name": "Tribonacci Constant", "replacement": "η"},
-	"V_dp": {"name": "Van der Pauw Constant", "replacement": "π/ln(2)"},
-	"V": {"name": "Viswanath Constant"},
-	"W_S": {"name": "Weierstrass Constant", "replacement": "W[S]"},
-	"W": {"name": "Wallis Constant"},
-	"Zeta3": {"replacement": "ζ(3)", "name": "Apery Constant"},
-	"z_975": {"name": "Z Score for 97.5 Percentile Point", "replacement": "z[97.5]"}
+const constants: { [abbrev: string]: Constant } = {
+	alpha_GW: { name: 'Goemans Williamson Constant', replacement: 'α[GW]' },
+	alpha_M: {
+		name: 'Madelung Constant',
+		replacement: 'α[M]',
+		url: 'https://en.wikipedia.org/wiki/Madelung_constant'
+	},
+	alpha_F: {
+		name: 'Foias Constant',
+		replacement: 'α[F]',
+		url: 'https://en.wikipedia.org/wiki/Foias_constant'
+	},
+	alpha: {
+		name: 'Second Feigenbaum Constant',
+		replacement: 'α',
+		url: 'https://en.wikipedia.org/wiki/Feigenbaum_constants#The_second_constant'
+	},
+	A_Pi: {
+		name: 'Mills Constant',
+		replacement: 'A[π]',
+		url: 'https://en.wikipedia.org/wiki/Mills%27_constant'
+	},
+	A: {
+		name: 'Glaisher Kinkelin Constant',
+		url: 'https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant'
+	},
+	beta_Levy: {
+		name: 'First Lévy Constant',
+		replacement: 'β',
+		url: 'https://en.wikipedia.org/wiki/L%C3%A9vy%27s_constant'
+	},
+	beta: {
+		name: 'Bernstein Constant',
+		replacement: 'β',
+		url: 'https://en.wikipedia.org/wiki/Bernstein%27s_constant'
+	},
+	B_2: {
+		name: 'Brun Constant',
+		replacement: 'B[2]',
+		url: 'https://en.wikipedia.org/wiki/Brun%27s_theorem'
+	},
+	B_H: {
+		name: 'Backhouse Constant',
+		replacement: 'B[H]',
+		url: 'https://en.wikipedia.org/wiki/Backhouse%27s_constant'
+	},
+	cbrt2: { replacement: 'cbrt(2)' },
+	cbrt3: { replacement: 'cbrt(3)' },
+	C_Artin: {
+		name: 'Artin Constant',
+		replacement: 'C[Artin]',
+		url: 'https://en.wikipedia.org/wiki/Artin%27s_conjecture_on_primitive_roots'
+	},
+	C_HBM: {
+		name: 'Heath-Brown–Moroz Constant',
+		replacement: 'C[HBM]',
+		url: 'https://en.wikipedia.org/wiki/Heath-Brown%E2%80%93Moroz_constant'
+	},
+	C_CE: {
+		name: 'Copeland Erdős Constant',
+		replacement: 'C[CE]',
+		url: 'https://en.wikipedia.org/wiki/Copeland%E2%80%93Erd%C5%91s_constant'
+	},
+	C_FT: {
+		name: 'Feller Tornier Constant',
+		replacement: 'C[FT]',
+		url: 'https://en.wikipedia.org/wiki/Feller%E2%80%93Tornier_constant'
+	},
+	C_10: {
+		name: 'Base 10 Champernowne Constant',
+		replacement: 'C[10]',
+		url: 'https://en.wikipedia.org/wiki/Champernowne_constant'
+	},
+	C_1: { name: 'First Continued Fraction Constant', replacement: 'C[1]' },
+	C_N: {
+		name: 'Niven Constant',
+		replacement: 'C[N]',
+		url: 'https://en.wikipedia.org/wiki/Niven%27s_constant'
+	},
+	C_P: {
+		name: 'Porter Constant',
+		replacement: 'C[P]',
+		url: 'https://en.wikipedia.org/wiki/Porter%27s_constant'
+	},
+	C_2: {
+		name: 'Second du Bois-Reymond Constant',
+		replacement: 'C[2]',
+		url: 'https://es.wikipedia.org/wiki/Constante_Du_Bois_Reymond'
+	},
+	C: { name: 'Catalan Constant', url: 'https://en.wikipedia.org/wiki/Catalan%27s_constant' },
+	c: {
+		name: 'Asymptotic Lebesgue Constant',
+		replacement: 'Λ[n]',
+		url: 'https://en.wikipedia.org/wiki/Lebesgue_constant'
+	},
+	delta_ETF: {
+		name: 'Erdős-Tenenbaum-Ford Constant',
+		replacement: 'δ[ETF]',
+		url: 'https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Tenenbaum%E2%80%93Ford_constant'
+	},
+	delta_G: {
+		name: 'Gompertz Constant',
+		replacement: 'δ[G]',
+		url: 'https://en.wikipedia.org/wiki/Gompertz_constant'
+	},
+	Delta_3: {
+		name: 'Robbins Constant',
+		replacement: '∆(3)',
+		url: 'https://en.wikipedia.org/wiki/Mean_line_segment_length#Cube_and_hypercubes'
+	},
+	delta: {
+		name: 'First Feigenbaum Constant',
+		replacement: 'δ',
+		url: 'https://en.wikipedia.org/wiki/Feigenbaum_constants#The_first_constant'
+	},
+	D_V: { name: 'Devicci Tesseract Constant', replacement: 'D[V]' },
+	D: { name: 'Dottie Number', url: 'https://en.wikipedia.org/wiki/Dottie_number' },
+	eLevy: { name: 'Second Lévy Constant', replacement: 'e^β' },
+	epi: {
+		name: 'Gelfond Constant',
+		replacement: 'e^π',
+		url: 'https://en.wikipedia.org/wiki/Gelfond%27s_constant'
+	},
+	E: {
+		name: 'Erdos Borwein constant',
+		url: 'https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Borwein_constant'
+	},
+	F: {
+		name: 'Fransén Robinson Constant',
+		url: 'https://en.wikipedia.org/wiki/Frans%C3%A9n%E2%80%93Robinson_constant'
+	},
+	gamma: {
+		name: 'Euler Mascheroni Constant',
+		url: 'https://en.wikipedia.org/wiki/Euler%27s_constant'
+	},
+	G_025: { replacement: 'Γ(0.25)' },
+	G_L: {
+		name: 'Gieseking Constant or Lobachevsky Constant',
+		replacement: 'G[L]',
+		url: 'https://mathworld.wolfram.com/GiesekingsConstant.html'
+	},
+	G_S: {
+		name: 'Gelfond-Schneider Constant or Hilbert Number',
+		replacement: '2^sqrt(2)',
+		url: 'https://en.wikipedia.org/wiki/Hilbert_number'
+	},
+	g: { name: 'Golden Angle', url: 'https://en.wikipedia.org/wiki/Golden_angle' },
+	G: { name: 'Gauss Constant (ϖ/π)', url: 'https://en.wikipedia.org/wiki/Lemniscate_constant' },
+	Kprime: {
+		replacement: 'Κ',
+		name: 'Kepler Bouwkamp Constant',
+		url: 'https://en.wikipedia.org/wiki/Kepler%E2%80%93Bouwkamp_constant'
+	},
+	K_0: {
+		name: 'Khinchin Constant',
+		replacement: 'K[0]',
+		url: 'https://en.wikipedia.org/wiki/Khinchin%27s_constant'
+	},
+	lambda_GD: {
+		name: 'Golomb Dickman Constant',
+		replacement: 'λ[GD]',
+		url: 'https://en.wikipedia.org/wiki/Golomb%E2%80%93Dickman_constant'
+	},
+	lambda_C: {
+		name: 'Conway Constant',
+		replacement: 'λ[C]',
+		url: 'https://en.wikipedia.org/wiki/Look-and-say_sequence#Growth_in_length'
+	},
+	ln2: { replacement: 'ln(2)' },
+	L_lim: {
+		name: 'Laplace Limit',
+		replacement: 'L[lim]',
+		url: 'https://en.wikipedia.org/wiki/Laplace_limit'
+	},
+	L_Lochs: {
+		name: 'Loch Constant',
+		replacement: 'L[Lochs]',
+		url: 'https://mathworld.wolfram.com/LochsConstant.html'
+	},
+	L_1: {
+		name: 'First Lemniscate Constant (ϖ/2)',
+		replacement: 'L[1]',
+		url: 'https://en.wikipedia.org/wiki/Lemniscate_constant'
+	},
+	L_2: {
+		name: 'Secnd Lemniscate Constant (π/(2ϖ))',
+		replacement: 'L[2]',
+		url: 'https://en.wikipedia.org/wiki/Lemniscate_constant'
+	},
+	L_R: {
+		name: 'Landau Ramanujan Constant',
+		replacement: 'L[R]',
+		url: 'https://en.wikipedia.org/wiki/Landau%E2%80%93Ramanujan_constant'
+	},
+	L_D: { name: 'Logarithmic Capacity of the Unit Disk', replacement: 'L[D]' },
+	L: {
+		name: 'Liouville Constant',
+		url: "https://en.wikipedia.org/wiki/Liouville_number#The_existence_of_Liouville_numbers_(Liouville's_constant)"
+	},
+	mu: {
+		replacement: 'μ',
+		name: 'Hexagonal Lattice Connective Constant',
+		url: 'https://en.wikipedia.org/wiki/Connective_constant'
+	},
+	M: {
+		name: 'Meissel Mertens Constant',
+		url: 'https://en.wikipedia.org/wiki/Meissel%E2%80%93Mertens_constant'
+	},
+	Omega: {
+		replacement: 'Ω',
+		name: 'Omega Constant',
+		url: 'https://en.wikipedia.org/wiki/Omega_constant'
+	},
+	phi: { name: 'Golden Ratio', url: 'https://en.wikipedia.org/wiki/Golden_ratio' },
+	psi_Fib: {
+		name: 'Reciprocal Fibonacci Constant',
+		replacement: 'ψ[Fib]',
+		url: 'https://en.wikipedia.org/wiki/Reciprocal_Fibonacci_constant'
+	},
+	psi: {
+		replacement: 'ψ',
+		name: 'Super Golden Ratio',
+		url: 'https://en.wikipedia.org/wiki/Supergolden_ratio'
+	},
+	Pi_2: {
+		name: 'Twin Primes Constant',
+		replacement: 'Π[2]',
+		url: 'https://en.wikipedia.org/wiki/Twin_prime'
+	},
+	P_Dragon: {
+		name: 'Paperfolding Constant',
+		replacement: 'P[Dragon]',
+		url: 'https://en.wikipedia.org/wiki/Regular_paperfolding_sequence#Paperfolding_constant'
+	},
+	P: {
+		name: 'Universal Parabolic Constant',
+		url: 'https://en.wikipedia.org/wiki/Universal_parabolic_constant'
+	},
+	q: {
+		name: 'Komornik–Loreti Constant',
+		url: 'https://en.wikipedia.org/wiki/Komornik%E2%80%93Loreti_constant'
+	},
+	root12of2: { replacement: 'nthRoot(2, 12)' },
+	rho_Pi: {
+		name: 'Prime Constant',
+		replacement: 'ρ[Pi]',
+		url: 'https://en.wikipedia.org/wiki/Prime_constant'
+	},
+	rho: {
+		name: 'Plastic Number',
+		replacement: 'Ρ',
+		url: 'https://en.wikipedia.org/wiki/Plastic_ratio'
+	},
+	R_S: {
+		name: 'Ramanujan Soldner Constant',
+		replacement: 'R[S]',
+		url: 'https://en.wikipedia.org/wiki/Ramanujan%E2%80%93Soldner_constant'
+	},
+	R: {
+		name: 'Ramanujan Constant',
+		url: "https://en.wikipedia.org/wiki/Heegner_number#Almost_integers_and_Ramanujan's_constant"
+	},
+	sigma_10: {
+		name: 'Salem Constant',
+		replacement: 'σ[10]',
+		url: 'https://mathworld.wolfram.com/SalemConstants.html'
+	},
+	sigma_S: {
+		name: 'Somos Quadratic Recurrence Constant',
+		replacement: 'σ[S]',
+		url: 'https://en.wikipedia.org/wiki/Somos%27_quadratic_recurrence_constant'
+	},
+	sigma: {
+		name: 'Hafner-Sarnak-McCurley Constant',
+		replacement: 'σ',
+		url: 'https://en.wikipedia.org/wiki/Hafner%E2%80%93Sarnak%E2%80%93McCurley_constant'
+	},
+	sqrt2: { replacement: 'sqrt(2)' },
+	sqrt3: { replacement: 'sqrt(3)' },
+	S_MRB: {
+		name: 'MRB Constant',
+		replacement: 'S[MRB]',
+		url: 'https://en.wikipedia.org/wiki/MRB_constant'
+	},
+	S_Pi: {
+		name: 'Stephens Constant',
+		replacement: 'S[Pi]',
+		url: 'https://en.wikipedia.org/wiki/Stephens%27_constant'
+	},
+	S: {
+		name: 'Sierpiński Constant',
+		url: 'https://en.wikipedia.org/wiki/Sierpi%C5%84ski%27s_constant'
+	},
+	theta_m: {
+		name: 'Magic Angle',
+		replacement: 'θ[m]',
+		url: 'https://en.wikipedia.org/wiki/Magic_angle'
+	},
+	tau: {
+		name: 'Prouhet Thue Morse Constant',
+		replacement: 'τ',
+		url: 'https://en.wikipedia.org/wiki/Prouhet%E2%80%93Thue%E2%80%93Morse_constant'
+	},
+	T_Pi: {
+		name: 'Taniguchi Constant',
+		replacement: 'T[Pi]',
+		url: 'https://mathworld.wolfram.com/TaniguchisConstant.html'
+	},
+	T: {
+		name: 'Tribonacci Constant',
+		replacement: 'η',
+		url: 'https://en.wikipedia.org/wiki/Generalizations_of_Fibonacci_numbers#Tribonacci_numbers'
+	},
+	V_dp: {
+		name: 'Van der Pauw Constant',
+		replacement: 'π/ln(2)',
+		url: 'https://en.wikipedia.org/wiki/Van_der_Pauw_method#Calculating_sheet_resistance'
+	},
+	V: {
+		name: 'Viswanath Constant',
+		url: 'https://en.wikipedia.org/wiki/Random_Fibonacci_sequence'
+	},
+	W_S: {
+		name: 'Weierstrass Constant',
+		replacement: 'W[S]',
+		url: 'https://mathworld.wolfram.com/WeierstrassConstant.html'
+	},
+	W: { name: 'Wallis Constant', url: 'https://mathworld.wolfram.com/WallissConstant.html' },
+	Zeta3: {
+		replacement: 'ζ(3)',
+		name: 'Apery Constant',
+		url: 'https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_constant#Irrational_number'
+	},
+	z_975: {
+		name: 'Z Score for 97.5 Percentile Point',
+		replacement: 'z[97.5]',
+		url: 'https://en.wikipedia.org/wiki/97.5th_percentile_point'
+	}
 };
 
 export default constants;


### PR DESCRIPTION
When constants were used in the closed form expressions, they were unnamed. It would be helpful to end users if the constants used were named, in case there are multiple constants with the same symbol or the symbol used is unfamiliar. The Wolfram results sometimes contain links, so introduced links to documentation when available.

<img width="466" alt="image" src="https://github.com/gt-sse-center/ramanujan-machine-web/assets/1794406/987f1ae7-b855-4714-a23d-f87a576a6ad6">
