### PR TITLE
allowing user to specify working precision

### DIFF
--- a/python-backend/constants.py
+++ b/python-backend/constants.py
@@ -1,7 +1,7 @@
 """
 A centralized listing of constants that are used as settings for the API
 """
-PRECISION = 30
+DEFAULT_PRECISION = 30
 HOSTS = ['localhost', '127.0.0.1']
 PORTS = ['5173', '80']
 # how many lines of a series to print for debugging purposes

--- a/python-backend/math_utils.py
+++ b/python-backend/math_utils.py
@@ -8,8 +8,6 @@ from sympy.core.numbers import Number
 
 import constants
 
-PRECISION = constants.PRECISION
-
 logger = logging.getLogger('rm_web_app')
 
 

--- a/python-backend/test_main.py
+++ b/python-backend/test_main.py
@@ -89,7 +89,7 @@ def test_generalized_compute_values() -> None:
               mpmath.mpf(1415240640000) / mpmath.mpf(283533296824),
               mpmath.mpf(8010210009600000) / mpmath.mpf(1604788039632960)]
     data = Input(a="(1 + 2 n) (5 + 17 n (1 + n))", b="-n^6", symbol="n", i=100)
-    (a, _, b, _, symbol) = parse(data)
+    (a, _, b, _, symbol, _) = parse(data)
     (convergents, numerators, denominators) = generalized_computed_values(a=a, b=b, iterations=10)
     assert (denominators[1] == mpmath.mpf(117))
     assert (denominators[2] == mpmath.mpf(62531))
@@ -110,7 +110,7 @@ def test_generalized_compute_values_with_simple_input() -> None:
               mpmath.fdiv(972, 1393),
               mpmath.fdiv(6961, 9976), mpmath.fdiv(56660, 81201)]
     data = Input(a="n", b="1", symbol="n", i=100)
-    (a, _, b, _, symbol) = parse(data)
+    (a, _, b, _, symbol, _) = parse(data)
     (convergents, numerators, denominators) = generalized_computed_values(a=a, b=b, iterations=10)
     assert (numerators[2] == mpmath.mpf(2))
     assert (numerators[3] == mpmath.mpf(7))
@@ -140,8 +140,8 @@ def test_simple_compute_values() -> None:
     values = [1, mpmath.fdiv(2, 3), mpmath.fdiv(7, 10), mpmath.fdiv(30, 43), mpmath.fdiv(157, 225),
               mpmath.fdiv(972, 1393),
               mpmath.fdiv(6961, 9976), mpmath.fdiv(56660, 81201)]
-    data = Input(a="n", b="1", symbol="n", i=100)
-    (a, _, b, _, symbol) = parse(data)
+    data = Input(a="n", b="1", symbol="n", i=100, precision=30)
+    (a, _, b, _, symbol, _) = parse(data)
     (convergents, numerators, denominators) = simple_computed_values(a=a, iterations=10)
     assert (numerators[2] == mpmath.mpf(2))
     assert (numerators[3] == mpmath.mpf(7))

--- a/react-frontend/cypress/e2e/frontend/test.cy.js
+++ b/react-frontend/cypress/e2e/frontend/test.cy.js
@@ -9,10 +9,11 @@ describe('landing form', () => {
 	const invalidMathInput = `4..`;
 
 	it('displays two input fields for polynomials and one for iterations', () => {
-		cy.get('input').should('have.length', 3);
+		cy.get('input').should('have.length', 4);
 		cy.get('input').first().should('have.text', '');
 		cy.get('input').eq(1).should('have.text', '');
 		cy.get('input').eq(2).should('have.value', '1000');
+		cy.get('input').eq(3).should('have.value', '30');
 	});
 
 	it('should be focused on first input element', () => {

--- a/react-frontend/src/App.css
+++ b/react-frontend/src/App.css
@@ -123,6 +123,14 @@ div.form-field input {
 	outline-color: var(--muted);
 	flex-grow: 1;
 }
+div.form-field input[name='precision'] {
+	padding: 0.5rem;
+	min-width: 100px;
+	font-size: 1rem;
+	color: var(--input-text);
+	outline-color: var(--muted);
+	flex-grow: 1;
+}
 div.form-field input:focus {
 	border-color: var(--muted);
 	outline-color: var(--muted);
@@ -208,6 +216,10 @@ div.limit-container {
 	margin-right: auto;
 	padding: 1rem;
 	font-size: 1.5rem;
+
+	& p {
+		overflow-wrap: anywhere;
+	}
 }
 .error-message {
 	color: var(--accent);
@@ -352,6 +364,7 @@ div.flex-wrapper {
 
 div.flex-child {
 	flex: 1;
+	align-self: baseline;
 }
 .metadata {
 	font-size: 0.8rem;

--- a/react-frontend/src/components/Charts.tsx
+++ b/react-frontend/src/components/Charts.tsx
@@ -41,16 +41,7 @@ type LirecConstantMetadata = {
 	url?: string;
 };
 
-function Charts({
-	a_n,
-	b_n,
-	limit,
-	convergesTo,
-	errorData,
-	deltaData,
-	reducedDeltaData,
-	toggleDisplay
-}: ChartProps) {
+function Charts({ a_n, b_n, limit, convergesTo, errorData, deltaData, toggleDisplay }: ChartProps) {
 	const [wolframResults, setWolframResults] = useState<WolframResult[]>();
 	const [constantMetadata, setConstantMetadata] = useState<ConstantMetadata[]>([]);
 	const [lirecConstantMetadata, setLirecConstantMetadata] = useState<LirecConstantMetadata[]>([]);
@@ -151,13 +142,6 @@ function Charts({
 		}
 	};
 
-	const trimLimit = () => {
-		if (limit) {
-			const decimalPosition = limit.indexOf('.');
-			return limit.substring(0, 30 + decimalPosition + 1);
-		}
-	};
-
 	const verify = () => {
 		if (limit) {
 			axios
@@ -209,7 +193,7 @@ function Charts({
 					<div>
 						<p>This is the value of the Polynomial Continued Fraction:</p>
 						<div className="limit-container">
-							<p className="center-text">{trimLimit()}</p>
+							<p className="center-text">{limit}</p>
 						</div>
 						<p className="footnote">
 							<i>
@@ -260,14 +244,14 @@ function Charts({
 										<MathJax inline dynamic>
 											{wrapExpression(l.expression)}
 										</MathJax>
-										is the {l.label}
+										&nbsp;is the {l.label}
 									</a>
 								) : (
 									<p className="footnote metadata" key={l.label}>
 										<MathJax inline dynamic>
 											{wrapExpression(l.expression)}
 										</MathJax>
-										is the {l.label}
+										&nbsp;is the {l.label}
 									</p>
 								)
 							)}
@@ -335,7 +319,6 @@ function Charts({
 						estimations for Delta:
 					</p>
 					<ScatterPlot id="delta_chart" data={deltaData} />
-					<ScatterPlot id="reduced_delta_chart" data={reducedDeltaData} />
 				</div>
 			</MathJaxContext>
 			<button

--- a/react-frontend/src/components/Form.tsx
+++ b/react-frontend/src/components/Form.tsx
@@ -8,10 +8,14 @@ interface PostBody {
 	b: string;
 	symbol: string | undefined;
 	i: number;
+	precision?: number;
 }
+
+const DEFAULT_PRECISION = 30;
 
 function Form() {
 	const [iterationCount, setIterationCount] = useState(1000);
+	const [precision, setPrecision] = useState(DEFAULT_PRECISION);
 	const [numeratorIsValid, setNumeratorValidity] = useState(false);
 	const [denominatorIsValid, setDenominatorValidity] = useState(false);
 	const [polynomialA, setPolynomialA] = useState('');
@@ -66,6 +70,12 @@ function Form() {
 		} else setIterationCount(iterations);
 	};
 
+	const validatePrecision = function (precision: number) {
+		if (precision > 100 || precision < 0) {
+			setPrecision(DEFAULT_PRECISION);
+		} else setPrecision(precision);
+	};
+
 	const submit = (e: any) => {
 		e.preventDefault();
 		setWaitingForResponse(true);
@@ -80,7 +90,8 @@ function Form() {
 				a: polynomialA,
 				b: polynomialB,
 				symbol: polynomialA.match(/([a-zA-Z])/)?.[0] ?? polynomialB.match(/([a-zA-Z])/)?.[0] ?? '',
-				i: iterationCount
+				i: iterationCount,
+				precision: precision
 			};
 
 			websocket.send(JSON.stringify(body));
@@ -188,6 +199,23 @@ function Form() {
 							/>
 						</div>
 					</div>
+					<div className="form-field">
+						<div>
+							<label>&nbsp;precision&nbsp;</label>
+						</div>
+						<div>
+							<input
+								type="number"
+								min="1"
+								max="100"
+								name="precision"
+								value={precision}
+								onChange={(event) => {
+									validatePrecision(Number(event.target.value));
+								}}
+							/>
+						</div>
+					</div>
 					<button>
 						<div className={spinnerClassFn()}></div>
 						<div className="button-text">Analyze</div>
@@ -203,7 +231,6 @@ function Form() {
 					convergesTo={convergesTo}
 					deltaData={deltaData}
 					errorData={errorData}
-					reducedDeltaData={reducedDeltaData}
 					toggleDisplay={() => {
 						setNoConvergence(false);
 						setShowCharts(!showCharts);


### PR DESCRIPTION
Users can now set the backend working precision. It is capped at 100 and prevents the user from entering an invalid value, resetting to the default 30 if the user tries.
<img width="299" alt="image" src="https://github.com/gt-sse-center/ramanujan-machine-web/assets/1794406/19a1c721-ee75-4df8-9afd-a22a2b07dfbb">

Adjusted formatting of the results to wrap longer, more precise, results.
<img width="321" alt="image" src="https://github.com/gt-sse-center/ramanujan-machine-web/assets/1794406/61355c8c-d47a-4582-8133-450b3077baa1">
